### PR TITLE
Adding options for UEFI boot

### DIFF
--- a/tinycore-repack.sh
+++ b/tinycore-repack.sh
@@ -21,7 +21,8 @@ find | fakeroot cpio -o -H newc | gzip -2 > tmpcoregz && fakeroot mv tmpcoregz .
 )
 
 genisoimage -l -J -R -V tinycore-$USER-$DATE \
-	-input-charset utf-8 \
 	-no-emul-boot -boot-load-size 4 -boot-info-table \
+	-iso-level 4 \
 	-b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
+	-eltorito-alt-boot -e EFI/BOOT/efiboot.img \
 	-o $ISO iso


### PR DESCRIPTION
I had to add these options to get the generated ISO to boot on an UEFI system.

I could see the difference between the original TinyCore ISO and the generated ISO with the `dumpet` tool.